### PR TITLE
[fix] remove 2s sleep after min-time-to-leader-slot ends

### DIFF
--- a/internal/failover/client.go
+++ b/internal/failover/client.go
@@ -410,7 +410,6 @@ func (c *Client) waitMinTimeToLeaderSlot() (err error) {
 
 			calculatedTimeToNextLeaderSlot = timeToNextLeaderSlot
 			sp.Title(style.RenderPinkString(fmt.Sprintf("next leader slot in %s > %s, proceeding...", stringTimeToNextLeaderSlot, stringMinTimeToLeaderSlot)))
-			time.Sleep(sleepDuration)
 			return nil
 		}
 	})


### PR DESCRIPTION
  - Removes a `time.Sleep(2s)` that ran after `waitMinTimeToLeaderSlot` confirmed
    the condition was met, before returning — pure UX delay with no functional purpose                                                                                       
  - Saves 2 seconds from the critical failover path on any failover where the                                                                                                
    validator is on the leader schedule   