### PR TITLE
[fix] fall back to cluster RPC when local gossip misses active peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Download and install the latest [release](https://github.com/SOL-Strategies/sola
 
 2. **Some focus and appreciation of what you're doing** — these can be high pucker factor operations regardless of tooling.
 
-3. **Local validator started with `--full-rpc-api`** — this tool calls `getClusterNodes` on the local RPC, which requires the validator to be started with the `--full-rpc-api` flag (Agave/Firedancer).
+3. **Local validator started with `--full-rpc-api`** — this tool calls `getClusterNodes` on the local RPC, which requires the validator to be started with the `--full-rpc-api` flag (Agave/Firedancer). For resilient peer discovery, configure a private cluster RPC that also supports `getClusterNodes`; it is used when the local validator's gossip view does not contain the peer.
 
 ## Configuration
 
@@ -131,9 +131,10 @@ validator:
   #            any other value is treated as a custom cluster (requires cluster_rpc_url)
   cluster: mainnet-beta
 
-  # (required for custom clusters) RPC URL for the cluster - must support getClusterNodes.
-  # For well-known clusters the built-in URL is used. For custom clusters, or if you need
-  # to override the default (e.g. to use a private RPC), set this explicitly.
+  # (required for custom clusters) RPC URL for the cluster.
+  # For well-known clusters the built-in URL is used unless this is set. A private endpoint
+  # that supports getClusterNodes is recommended: peer discovery falls back to it when the
+  # local validator's gossip view does not contain the expected peer.
   # cluster_rpc_url: <solana_compatible_rpc_endpoint>
 
   # optional display name used in failover plans, logs, and hook templates
@@ -425,6 +426,24 @@ Post-hooks always run even if the set-identity command fails. Pre hooks are inte
 ### Rollback is shown in the failover plan
 
 When `rollback.enabled: true`, the pre-failover plan shows the rollback commands that would run on each node if the failover fails, giving operators visibility before they confirm.
+
+## Troubleshooting gossip peer discovery
+
+`svf` determines this node's role from the local validator RPC. When looking for the active peer by pubkey, it checks the local RPC first and then `validator.cluster_rpc_url`. This matters because `getClusterNodes` represents the responding validator's own in-memory gossip/CRDS view; it can differ from the independent view collected by `solana gossip`, especially in mixed-client Agave/Firedancer deployments.
+
+To inspect exactly what the local RPC reports:
+
+```shell
+PK=<active_identity_pubkey>
+RPC=http://127.0.0.1:8899
+
+curl -sS "$RPC" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getClusterNodes"}' |
+  jq --arg pk "$PK" '{error, count:(.result | length), match:[.result[] | select(.pubkey == $pk)]}'
+```
+
+If `match` is empty locally while `solana gossip` shows the peer, configure a trusted private `cluster_rpc_url` that exposes `getClusterNodes`. `svf` still fails closed if neither RPC view contains the expected active pubkey.
 
 ## Developing
 

--- a/internal/solana/client.go
+++ b/internal/solana/client.go
@@ -142,12 +142,12 @@ func (c *Client) NodeFromPubkey(pubkey string) (*Node, error) {
 func (c *Client) getClusterNodes() ([]*rpc.GetClusterNodesResult, error) {
 	nodes, err := c.localRPCClient.GetClusterNodes(context.Background())
 	if err != nil {
-		return nil, wrapGetClusterNodesErr(err)
+		return nil, wrapLocalGetClusterNodesErr(err)
 	}
 	return nodes, nil
 }
 
-func wrapGetClusterNodesErr(err error) error {
+func wrapLocalGetClusterNodesErr(err error) error {
 	var rpcErr *jsonrpc.RPCError
 	if errors.As(err, &rpcErr) && rpcErr.Code == jsonRPCMethodNotFound {
 		return fmt.Errorf("%w; start the local validator with --full-rpc-api to enable getClusterNodes", err)
@@ -174,18 +174,55 @@ func (c *Client) nodeFromIP(ip string) (node *rpc.GetClusterNodesResult, err err
 }
 
 func (c *Client) gossipNodeFromPubkey(pubkey string) (node *rpc.GetClusterNodesResult, err error) {
-	nodes, err := c.getClusterNodes()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, node := range nodes {
-		if node.Pubkey.String() == pubkey {
+	localNodes, localErr := c.getClusterNodes()
+	if localErr == nil {
+		if node := findGossipNodeFromPubkey(localNodes, pubkey); node != nil {
+			c.loggerLocal.Debug("gossip peer found by pubkey", "pubkey", pubkey, "node_count", len(localNodes))
 			return node, nil
 		}
+		c.loggerLocal.Debug("gossip peer not found by pubkey", "pubkey", pubkey, "node_count", len(localNodes))
+	} else {
+		c.loggerLocal.Debug("failed to query gossip peer by pubkey", "pubkey", pubkey, "err", localErr)
 	}
 
-	return nil, fmt.Errorf("gossip node not found for pubkey: %s", pubkey)
+	clusterNodes, clusterErr := c.networkRPCClient.GetClusterNodes(context.Background())
+	if clusterErr == nil {
+		if node := findGossipNodeFromPubkey(clusterNodes, pubkey); node != nil {
+			c.loggerNetwork.Debug("gossip peer found by pubkey", "pubkey", pubkey, "node_count", len(clusterNodes))
+			return node, nil
+		}
+		c.loggerNetwork.Debug("gossip peer not found by pubkey", "pubkey", pubkey, "node_count", len(clusterNodes))
+	} else {
+		c.loggerNetwork.Debug("failed to query gossip peer by pubkey", "pubkey", pubkey, "err", clusterErr)
+	}
+
+	return nil, gossipNodeFromPubkeyError(pubkey, len(localNodes), localErr, len(clusterNodes), clusterErr)
+}
+
+func findGossipNodeFromPubkey(nodes []*rpc.GetClusterNodesResult, pubkey string) *rpc.GetClusterNodesResult {
+	for _, node := range nodes {
+		if node != nil && node.Pubkey.String() == pubkey {
+			return node
+		}
+	}
+	return nil
+}
+
+func gossipNodeFromPubkeyError(pubkey string, localCount int, localErr error, clusterCount int, clusterErr error) error {
+	localResult := fmt.Sprintf("returned %d nodes without a match", localCount)
+	if localErr != nil {
+		localResult = fmt.Sprintf("failed: %v", localErr)
+	}
+	clusterResult := fmt.Sprintf("returned %d nodes without a match", clusterCount)
+	if clusterErr != nil {
+		clusterResult = fmt.Sprintf("failed: %v", clusterErr)
+	}
+	return fmt.Errorf(
+		"gossip node not found for pubkey: %s (local RPC %s; cluster RPC %s)",
+		pubkey,
+		localResult,
+		clusterResult,
+	)
 }
 
 // NodeFromIPWithExpectedPubkey returns a Node from an IP address, preferring the entry

--- a/internal/solana/client_test.go
+++ b/internal/solana/client_test.go
@@ -204,7 +204,7 @@ func TestGossipClient_NodeFromIP_NilGossip(t *testing.T) {
 
 func TestGossipClient_NodeFromPubkey_Success(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Setup mock expectations
 	expectedNodes := []*rpc.GetClusterNodesResult{
@@ -235,11 +235,12 @@ func TestGossipClient_NodeFromPubkey_Success(t *testing.T) {
 	assert.Equal(t, "1.16.0", node.Version())
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertNotCalled(t, "GetClusterNodes", mock.Anything)
 }
 
 func TestGossipClient_NodeFromPubkey_NotFound(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Setup mock expectations
 	expectedNodes := []*rpc.GetClusterNodesResult{
@@ -252,6 +253,7 @@ func TestGossipClient_NodeFromPubkey_NotFound(t *testing.T) {
 	}
 
 	localMock.On("GetClusterNodes", mock.Anything).Return(expectedNodes, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return(expectedNodes, nil)
 
 	// Test the function
 	node, err := client.NodeFromPubkey("9999999999999999999999999999999999999999999999999999999999999999")
@@ -260,16 +262,20 @@ func TestGossipClient_NodeFromPubkey_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, node)
 	assert.Contains(t, err.Error(), "gossip node not found for pubkey: 9999999999999999999999999999999999999999999999999999999999999999")
+	assert.Contains(t, err.Error(), "local RPC returned 1 nodes without a match")
+	assert.Contains(t, err.Error(), "cluster RPC returned 1 nodes without a match")
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestGossipClient_NodeFromPubkey_RPCError(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Setup mock expectations
 	localMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("RPC connection failed"))
+	networkMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("cluster RPC forbidden"))
 
 	// Test the function
 	node, err := client.NodeFromPubkey("11111111111111111111111111111111")
@@ -278,8 +284,64 @@ func TestGossipClient_NodeFromPubkey_RPCError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, node)
 	assert.Contains(t, err.Error(), "RPC connection failed")
+	assert.Contains(t, err.Error(), "cluster RPC forbidden")
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
+}
+
+func TestGossipClient_NodeFromPubkey_ClusterFallback(t *testing.T) {
+	client, localMock, networkMock := createTestClient()
+	targetPubkey := createTestPublicKey(2)
+
+	localNodes := []*rpc.GetClusterNodesResult{
+		{
+			Pubkey:  createTestPublicKey(1),
+			Gossip:  stringPtr("192.168.1.100:8001"),
+			Version: stringPtr("3.0.0"),
+		},
+	}
+	clusterNodes := []*rpc.GetClusterNodesResult{
+		{
+			Pubkey:  targetPubkey,
+			Gossip:  stringPtr("79.127.227.20:8001"),
+			Version: stringPtr("1.1.3"),
+		},
+	}
+	localMock.On("GetClusterNodes", mock.Anything).Return(localNodes, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return(clusterNodes, nil)
+
+	node, err := client.NodeFromPubkey(targetPubkey.String())
+
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, targetPubkey.String(), node.PubKey())
+	assert.Equal(t, "79.127.227.20", node.IP())
+	assert.Equal(t, "1.1.3", node.Version())
+	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
+}
+
+func TestGossipClient_NodeFromPubkey_ClusterFallbackAfterLocalRPCError(t *testing.T) {
+	client, localMock, networkMock := createTestClient()
+	targetPubkey := createTestPublicKey(2)
+	clusterNodes := []*rpc.GetClusterNodesResult{
+		{
+			Pubkey:  targetPubkey,
+			Gossip:  stringPtr("79.127.227.20:8001"),
+			Version: stringPtr("1.1.3"),
+		},
+	}
+	localMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("local RPC unavailable"))
+	networkMock.On("GetClusterNodes", mock.Anything).Return(clusterNodes, nil)
+
+	node, err := client.NodeFromPubkey(targetPubkey.String())
+
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, targetPubkey.String(), node.PubKey())
+	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestNodeFromIPWithExpectedPubkey_MatchFound(t *testing.T) {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -261,20 +262,11 @@ func (v *Validator) configureRPCClient(localRPCURL, solanaClusterName, clusterRP
 		)
 	}
 
-	// determine the cluster RPC URL: use built-in URL for known clusters,
-	// otherwise require cluster_rpc_url from config
-	var solanaClusterRPCURL string
-	if utils.IsKnownCluster(solanaClusterName) {
-		solanaClusterRPCURL = constants.SolanaClusters[solanaClusterName].RPC
-	} else {
-		if clusterRPCURL == "" {
-			return fmt.Errorf(
-				"cluster_rpc_url is required for custom cluster %q (known clusters: %s)",
-				solanaClusterName,
-				strings.Join(constants.SolanaClusterNames, ", "),
-			)
-		}
-		solanaClusterRPCURL = clusterRPCURL
+	// An explicit cluster RPC URL overrides the built-in endpoint for known clusters.
+	// This allows operators to use a private endpoint that supports getClusterNodes.
+	solanaClusterRPCURL, err := resolveClusterRPCURL(solanaClusterName, clusterRPCURL)
+	if err != nil {
+		return err
 	}
 
 	avgSlotDuration, err := time.ParseDuration(averageSlotDuration)
@@ -284,8 +276,8 @@ func (v *Validator) configureRPCClient(localRPCURL, solanaClusterName, clusterRP
 
 	v.logger.Debug("rpc client configured",
 		"cluster", solanaClusterName,
-		"local_rpc_url", localRPCURL,
-		"cluster_rpc_url", solanaClusterRPCURL,
+		"local_rpc_url", rpcURLForLog(localRPCURL),
+		"cluster_rpc_url", rpcURLForLog(solanaClusterRPCURL),
 	)
 
 	v.RPCAddress = localRPCURL
@@ -296,6 +288,28 @@ func (v *Validator) configureRPCClient(localRPCURL, solanaClusterName, clusterRP
 	})
 
 	return nil
+}
+
+func rpcURLForLog(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "<configured>"
+	}
+	return parsedURL.Scheme + "://" + parsedURL.Host
+}
+
+func resolveClusterRPCURL(solanaClusterName, clusterRPCURL string) (string, error) {
+	if clusterRPCURL != "" {
+		return clusterRPCURL, nil
+	}
+	if utils.IsKnownCluster(solanaClusterName) {
+		return constants.SolanaClusters[solanaClusterName].RPC, nil
+	}
+	return "", fmt.Errorf(
+		"cluster_rpc_url is required for custom cluster %q (known clusters: %s)",
+		solanaClusterName,
+		strings.Join(constants.SolanaClusterNames, ", "),
+	)
 }
 
 // configureBin ensures the validator binary exists and sets it

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -260,6 +260,33 @@ func TestConfigureRPCClient_CustomCluster_MissingClusterRPCURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "cluster_rpc_url is required")
 }
 
+func TestResolveClusterRPCURL_KnownClusterDefault(t *testing.T) {
+	url, err := resolveClusterRPCURL("mainnet-beta", "")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.mainnet-beta.solana.com", url)
+}
+
+func TestResolveClusterRPCURL_KnownClusterOverride(t *testing.T) {
+	url, err := resolveClusterRPCURL("mainnet-beta", "https://private-rpc.example.com")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://private-rpc.example.com", url)
+}
+
+func TestResolveClusterRPCURL_CustomCluster(t *testing.T) {
+	url, err := resolveClusterRPCURL("custom-mainnet", "https://custom-rpc.example.com")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://custom-rpc.example.com", url)
+}
+
+func TestRPCURLForLog_RedactsCredentialsAndPath(t *testing.T) {
+	loggedURL := rpcURLForLog("https://user:secret@private-rpc.example.com/v1/key?api-key=secret")
+
+	assert.Equal(t, "https://private-rpc.example.com", loggedURL)
+}
+
 // ============================================================================
 // Tests for configureBin
 // ============================================================================


### PR DESCRIPTION
  - Fall back to the configured cluster RPC when the local getClusterNodes view misses the active peer.
  - Allow cluster_rpc_url to override built-in endpoints for known clusters.
  - Preserve local-only role detection and post-failover identity checks.
  - Improve source-specific peer lookup diagnostics.
  - Redact credentials and paths from RPC URLs in debug logs.
  - Add Agave/Firedancer regression coverage and troubleshooting documentation.