### PR TITLE
[feature] add config-driven log levels and formats with CLI precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ By default, `run` executes in **dry-run mode**: the tower file is synced and all
 | Flag                      | Default                                                      | Description                                   |
 | ------------------------- | ------------------------------------------------------------ | --------------------------------------------- |
 | `-c, --config <path>`     | `~/solana-validator-failover/solana-validator-failover.yaml` | Path to config file.                          |
-| `-l, --log-level <level>` | `info`                                                       | Log level (`debug`, `info`, `warn`, `error`). |
+| `-l, --log-level <level>` | —                                                            | Override `log.level` (`debug`, `info`, `warn`, `error`, `fatal`). |
 | `-n, --no-update-check`   | `false`                                                      | Skip the startup update check. Overrides `update.check_on_startup` in the config file. |
 
 ### Peer selection
@@ -121,6 +121,15 @@ Download and install the latest [release](https://github.com/SOL-Strategies/sola
 
 ```yaml
 # default --config=~/solana-validator-failover/solana-validator-failover.yaml
+log:
+  # minimum log level; overridden by --log-level when explicitly supplied
+  # default: info; one of: debug, info, warn, error, fatal
+  level: info
+
+  # log output format
+  # default: text; one of: text, logfmt, json
+  format: text
+
 validator:
   # path of validator program to use when issuing set-identity commands
   # default: agave-validator

--- a/cmd/solanavalidatorfailover/root.go
+++ b/cmd/solanavalidatorfailover/root.go
@@ -19,6 +19,7 @@ var (
 	logLevel      string
 	noUpdateCheck bool
 	updateCh      chan string
+	loadedConfig  *config.SolanaValidatorFailover
 	rootCmd       = &cobra.Command{
 		Aliases: []string{},
 		Use:     style.RenderPurpleString(constants.AppName),
@@ -47,7 +48,7 @@ func Execute() {
 	// config flag
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", config.DefaultConfigPath, "path to config file")
 	// log level flag
-	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "log level")
+	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "", "log level (debug, info, warn, error, fatal) - overrides config log.level")
 	// update check flag
 	rootCmd.PersistentFlags().BoolVarP(&noUpdateCheck, "no-update-check", "n", false, "skip update check")
 
@@ -66,14 +67,18 @@ func init() {
 }
 
 func persistentPreRun(cmd *cobra.Command, args []string) error {
-	logging.Configure(logLevel)
+	cfg, err := config.NewFromFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	loadedConfig = cfg
+
+	logging.Configure(cfg.Log.Level, cfg.Log.Format, logLevel)
 
 	// --no-update-check flag always wins; otherwise defer to config (default: true).
 	checkUpdate := !noUpdateCheck
 	if checkUpdate {
-		if cfg, err := config.NewFromFile(configPath); err == nil {
-			checkUpdate = cfg.Update.CheckOnStartup
-		}
+		checkUpdate = cfg.Update.CheckOnStartup
 	}
 
 	if checkUpdate {

--- a/cmd/solanavalidatorfailover/root_test.go
+++ b/cmd/solanavalidatorfailover/root_test.go
@@ -1,0 +1,73 @@
+package solanavalidatorfailover
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/log"
+	appLogging "github.com/sol-strategies/solana-validator-failover/internal/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeRootTestConfig(t *testing.T, level, format string) string {
+	t.Helper()
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	content := "log:\n  level: " + level + "\n  format: " + format + "\nupdate:\n  check_on_startup: false\n"
+	require.NoError(t, os.WriteFile(configFile, []byte(content), 0o644))
+	return configFile
+}
+
+func resetRootTestState(t *testing.T) {
+	t.Helper()
+	previousConfigPath := configPath
+	previousLogLevel := logLevel
+	previousNoUpdateCheck := noUpdateCheck
+	previousLoadedConfig := loadedConfig
+	t.Cleanup(func() {
+		configPath = previousConfigPath
+		logLevel = previousLogLevel
+		noUpdateCheck = previousNoUpdateCheck
+		loadedConfig = previousLoadedConfig
+		log.SetOutput(os.Stderr)
+		appLogging.Configure("info", "text", "")
+	})
+}
+
+func TestPersistentPreRun_UsesConfigLogging(t *testing.T) {
+	resetRootTestState(t)
+	configPath = writeRootTestConfig(t, "debug", "json")
+	logLevel = ""
+	noUpdateCheck = false
+	appLogging.Configure("info", "text", "")
+	var output bytes.Buffer
+	log.SetOutput(&output)
+
+	err := persistentPreRun(rootCmd, nil)
+	require.NoError(t, err)
+	log.Debug("configured-from-file")
+
+	require.NotNil(t, loadedConfig)
+	assert.Equal(t, "debug", loadedConfig.Log.Level)
+	assert.Equal(t, log.DebugLevel, log.GetLevel())
+	var record map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output.String())), &record))
+	assert.Equal(t, "configured-from-file", record["msg"])
+}
+
+func TestPersistentPreRun_CLILevelOverridesConfig(t *testing.T) {
+	resetRootTestState(t)
+	configPath = writeRootTestConfig(t, "warn", "text")
+	logLevel = "debug"
+	noUpdateCheck = false
+
+	err := persistentPreRun(rootCmd, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, log.DebugLevel, log.GetLevel())
+	assert.Equal(t, "warn", loadedConfig.Log.Level)
+}

--- a/cmd/solanavalidatorfailover/run.go
+++ b/cmd/solanavalidatorfailover/run.go
@@ -2,7 +2,6 @@ package solanavalidatorfailover
 
 import (
 	"github.com/charmbracelet/log"
-	"github.com/sol-strategies/solana-validator-failover/internal/config"
 	"github.com/sol-strategies/solana-validator-failover/internal/validator"
 	"github.com/spf13/cobra"
 )
@@ -21,12 +20,11 @@ var (
 		Short:        "run a failover - automatically detects what to do based on the node's role (active or passive)",
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cfg, err := config.NewFromFile(configPath)
-			if err != nil {
-				log.Fatal("failed to load config", "err", err)
+			if loadedConfig == nil {
+				log.Fatal("config was not loaded before running command")
 			}
 
-			v, err := validator.NewFromConfig(&cfg.Validator)
+			v, err := validator.NewFromConfig(&loadedConfig.Validator)
 			if err != nil {
 				log.Fatal("failed to create validator", "err", err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,7 @@ type UpdateConfig struct {
 
 // SolanaValidatorFailover is the configuration for the program
 type SolanaValidatorFailover struct {
+	Log       LogConfig        `mapstructure:"log"`
 	Validator validator.Config `mapstructure:"validator"`
 	Update    UpdateConfig     `mapstructure:"update"`
 }
@@ -96,6 +97,8 @@ func (s *SolanaValidatorFailover) LoadFromConfigFile(configPath string) (err err
 	v.SetConfigFile(loadConfigPath)
 
 	// Set defaults
+	v.SetDefault("log.level", DefaultLogLevel)
+	v.SetDefault("log.format", DefaultLogFormat)
 	v.SetDefault("validator.bin", DefaultBin)
 	v.SetDefault("validator.average_slot_duration", DefaultAverageSlotDuration)
 	v.SetDefault("validator.cluster", DefaultCluster)
@@ -118,5 +121,9 @@ func (s *SolanaValidatorFailover) LoadFromConfigFile(configPath string) (err err
 	}
 
 	// Unmarshal into the full config structure
-	return v.Unmarshal(&s)
+	if err := v.Unmarshal(s); err != nil {
+		return err
+	}
+
+	return s.Log.Validate()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -51,6 +51,8 @@ validator:
 
 	// Verify the configuration was loaded correctly
 	assert.Equal(t, "test-validator", cfg.Validator.Bin)
+	assert.Equal(t, DefaultLogLevel, cfg.Log.Level)
+	assert.Equal(t, DefaultLogFormat, cfg.Log.Format)
 	assert.Equal(t, "testnet", cfg.Validator.Cluster)
 	assert.Equal(t, "http://localhost:8899", cfg.Validator.RPCAddress)
 	assert.Equal(t, "/tmp/ledger", cfg.Validator.LedgerDir)
@@ -133,6 +135,8 @@ validator:
 
 	// Verify defaults are set correctly
 	assert.Equal(t, DefaultBin, cfg.Validator.Bin)                                                                      // default
+	assert.Equal(t, DefaultLogLevel, cfg.Log.Level)                                                                     // default
+	assert.Equal(t, DefaultLogFormat, cfg.Log.Format)                                                                   // default
 	assert.Equal(t, DefaultCluster, cfg.Validator.Cluster)                                                              // from config
 	assert.Equal(t, DefaultFailoverServerPort, cfg.Validator.Failover.Server.Port)                                      // default
 	assert.Equal(t, DefaultFailoverServerHeartbeatInterval, cfg.Validator.Failover.Server.HeartbeatInterval)            // default
@@ -141,6 +145,59 @@ validator:
 	assert.Equal(t, DefaultFailoverMonitorCreditSamplesCount, cfg.Validator.Failover.Monitor.CreditSamples.Count)       // default
 	assert.Equal(t, DefaultFailoverMonitorCreditSamplesInterval, cfg.Validator.Failover.Monitor.CreditSamples.Interval) // default
 	assert.Equal(t, DefaultTowerFileNameTemplate, cfg.Validator.Tower.FileNameTemplate)                                 // default
+}
+
+func TestLoadFromConfigFile_WithLogConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "log-config.yaml")
+	configContent := `
+log:
+  level: debug
+  format: json
+validator:
+  cluster: testnet
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+
+	cfg, err := NewFromFile(configPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, "debug", cfg.Log.Level)
+	assert.Equal(t, "json", cfg.Log.Format)
+}
+
+func TestLoadFromConfigFile_InvalidLogLevel(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "invalid-log-level.yaml")
+	configContent := `
+log:
+  level: verbose
+validator:
+  cluster: testnet
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+
+	_, err := NewFromFile(configPath)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "log.level must be one of debug, info, warn, error, fatal")
+}
+
+func TestLoadFromConfigFile_InvalidLogFormat(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "invalid-log-format.yaml")
+	configContent := `
+log:
+  format: xml
+validator:
+  cluster: testnet
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+
+	_, err := NewFromFile(configPath)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "log.format must be one of text, json, logfmt")
 }
 
 func TestLoadFromConfigFile_WithInvalidYAML(t *testing.T) {

--- a/internal/config/log.go
+++ b/internal/config/log.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/log"
+)
+
+const (
+	DefaultLogLevel  = "info"
+	DefaultLogFormat = "text"
+)
+
+var validLogFormats = map[string]struct{}{
+	"text":   {},
+	"json":   {},
+	"logfmt": {},
+}
+
+// LogConfig holds global logging settings.
+type LogConfig struct {
+	Level  string `mapstructure:"level"`
+	Format string `mapstructure:"format"`
+}
+
+// Validate checks that the configured level and formatter are supported.
+func (c LogConfig) Validate() error {
+	if _, err := log.ParseLevel(c.Level); err != nil {
+		return fmt.Errorf("log.level must be one of debug, info, warn, error, fatal - got: %s", c.Level)
+	}
+	if _, ok := validLogFormats[c.Format]; !ok {
+		return fmt.Errorf("log.format must be one of text, json, logfmt - got: %s", c.Format)
+	}
+	return nil
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -7,21 +7,46 @@ import (
 	"github.com/charmbracelet/log"
 )
 
+var logFormatters = map[string]log.Formatter{
+	"text":   log.TextFormatter,
+	"json":   log.JSONFormatter,
+	"logfmt": log.LogfmtFormatter,
+}
+
 // New returns a logger with the given component as its prefix.
 func New(component string) *log.Logger {
 	return log.WithPrefix(component)
 }
 
-// Configure sets the global log level, time format and colour styles.
-// Call once at startup before any log output is produced.
-func Configure(level string) {
-	parsedLevel, err := log.ParseLevel(level)
+// Configure sets the global logger from config, with an optional CLI level override.
+// An invalid CLI override is reported and the validated config level is retained.
+func Configure(configLevel, format, cliLevel string) {
+	parsedLevel, err := log.ParseLevel(configLevel)
 	if err != nil {
-		log.Error("invalid log level, defaulting to info", "level", level, "err", err)
+		log.Error("invalid config log level, defaulting to info", "level", configLevel, "err", err)
 		parsedLevel = log.InfoLevel
 	}
 
+	if cliLevel != "" {
+		cliParsedLevel, cliErr := log.ParseLevel(cliLevel)
+		if cliErr != nil {
+			// Ensure this error is visible even if a previous logger configuration used
+			// a level higher than error. The config level is applied immediately below.
+			log.SetLevel(log.InfoLevel)
+			log.Error("invalid CLI log level, using configured level", "invalid_level", cliLevel, "configured_level", configLevel, "err", cliErr)
+		} else {
+			parsedLevel = cliParsedLevel
+		}
+	}
+
+	formatter, ok := logFormatters[format]
+	if !ok {
+		log.Error("invalid config log format, defaulting to text", "format", format)
+		formatter = log.TextFormatter
+	}
+
 	log.SetLevel(parsedLevel)
+	log.SetFormatter(formatter)
 	log.SetTimeFunction(func(t time.Time) time.Time { return t.UTC() })
 	log.SetTimeFormat("2006-01-02T15:04:05.000Z07:00")
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,93 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetLogger(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		Configure("info", "text", "")
+	})
+}
+
+func TestConfigure_UsesConfigLevelWhenCLILevelIsEmpty(t *testing.T) {
+	resetLogger(t)
+
+	Configure("warn", "text", "")
+
+	assert.Equal(t, log.WarnLevel, log.GetLevel())
+}
+
+func TestConfigure_CLILevelOverridesConfig(t *testing.T) {
+	resetLogger(t)
+
+	Configure("warn", "text", "debug")
+
+	assert.Equal(t, log.DebugLevel, log.GetLevel())
+}
+
+func TestConfigure_InvalidCLILevelUsesConfig(t *testing.T) {
+	resetLogger(t)
+	var output bytes.Buffer
+	log.SetOutput(&output)
+
+	Configure("warn", "text", "verbose")
+
+	assert.Equal(t, log.WarnLevel, log.GetLevel())
+	assert.Contains(t, output.String(), "invalid CLI log level")
+}
+
+func TestConfigure_Formatters(t *testing.T) {
+	tests := []struct {
+		name       string
+		format     string
+		assertBody func(t *testing.T, output string)
+	}{
+		{
+			name:   "text",
+			format: "text",
+			assertBody: func(t *testing.T, output string) {
+				assert.Contains(t, output, "formatter-test")
+			},
+		},
+		{
+			name:   "logfmt",
+			format: "logfmt",
+			assertBody: func(t *testing.T, output string) {
+				assert.Contains(t, output, `msg=formatter-test`)
+			},
+		},
+		{
+			name:   "json",
+			format: "json",
+			assertBody: func(t *testing.T, output string) {
+				var record map[string]any
+				require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &record))
+				assert.Equal(t, "formatter-test", record["msg"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetLogger(t)
+			var output bytes.Buffer
+			log.SetOutput(&output)
+			Configure("info", tt.format, "")
+
+			log.Info("formatter-test")
+
+			tt.assertBody(t, output.String())
+		})
+	}
+}


### PR DESCRIPTION
  - Add top-level log.level and log.format configuration.
  - Support debug, info, warn, error, and fatal levels.
  - Support text, logfmt, and json output formats.
  - Make explicit --log-level values override log.level.
  - Retain the configured level when an invalid CLI override is supplied.
  - Validate logging configuration during startup.
  - Load and reuse configuration once during command execution.
  - Add configuration, formatter, and CLI-precedence tests.
  - Update README configuration and flag documentation.