### PR TITLE
[fix] gossip apply cluster RPC fallback to all node lookups

### DIFF
--- a/internal/failover/server.go
+++ b/internal/failover/server.go
@@ -295,9 +295,14 @@ func (s *Server) handleFailoverStream(stream *quic.Stream) {
 		return
 	}
 
-	// query gossip for client by its public IP
-	s.logger.Debugf("querying gossip for active node IP %s", s.failoverStream.GetActiveNodeInfo().PublicIP)
-	gossipActiveNode, err := s.solanaRPCClient.NodeFromIP(s.failoverStream.GetActiveNodeInfo().PublicIP)
+	// Query gossip for the client by both its public IP and configured active identity.
+	activeNodeInfo := s.failoverStream.GetActiveNodeInfo()
+	expectedActivePubkey := activeNodeInfo.Identities.Active.PubKey()
+	s.logger.Debug("querying gossip for active node",
+		"public_ip", activeNodeInfo.PublicIP,
+		"pubkey", expectedActivePubkey,
+	)
+	gossipActiveNode, err := s.solanaRPCClient.NodeFromIPWithExpectedPubkey(activeNodeInfo.PublicIP, expectedActivePubkey)
 	if err != nil {
 		s.failoverStream.LogErrorWithSetMessagef("Failed to validate active node: %v", err)
 		if s.failoverStream.Encode() != nil {
@@ -306,13 +311,9 @@ func (s *Server) handleFailoverStream(stream *quic.Stream) {
 		return
 	}
 
-	// ensure the failover request comes from the active node
-	if gossipActiveNode.IP() != s.failoverStream.GetActiveNodeInfo().PublicIP {
-		s.failoverStream.LogErrorWithSetMessagef(
-			"Failed to validate active node: active node IP %s does not match expected IP %s",
-			gossipActiveNode.IP(),
-			s.failoverStream.GetActiveNodeInfo().PublicIP,
-		)
+	// Ensure the failover request comes from the configured active node.
+	if err := validateActiveGossipIdentity(gossipActiveNode.IP(), gossipActiveNode.PubKey(), activeNodeInfo.PublicIP, expectedActivePubkey); err != nil {
+		s.failoverStream.LogErrorWithSetMessagef("Failed to validate active node: %v", err)
 		if s.failoverStream.Encode() != nil {
 			return
 		}
@@ -607,6 +608,21 @@ func (s *Server) handleFailoverStream(stream *quic.Stream) {
 		}
 	}
 	s.cancel()
+}
+
+func validateActiveGossipIdentity(actualIP, actualPubkey, expectedIP, expectedPubkey string) error {
+	if actualIP != expectedIP {
+		return fmt.Errorf("active node IP %s does not match expected IP %s", actualIP, expectedIP)
+	}
+	if actualPubkey != expectedPubkey {
+		return fmt.Errorf(
+			"active node pubkey %s at IP %s does not match expected pubkey %s",
+			actualPubkey,
+			actualIP,
+			expectedPubkey,
+		)
+	}
+	return nil
 }
 
 // confirmGossipNodesPostFailover confirms that the gossip nodes have switched roles post-failover

--- a/internal/failover/server_test.go
+++ b/internal/failover/server_test.go
@@ -1,0 +1,55 @@
+package failover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateActiveGossipIdentity(t *testing.T) {
+	tests := []struct {
+		name           string
+		actualIP       string
+		actualPubkey   string
+		expectedIP     string
+		expectedPubkey string
+		errorContains  string
+	}{
+		{
+			name:           "matching IP and pubkey",
+			actualIP:       "79.127.227.20",
+			actualPubkey:   "active-pubkey",
+			expectedIP:     "79.127.227.20",
+			expectedPubkey: "active-pubkey",
+		},
+		{
+			name:           "IP mismatch",
+			actualIP:       "79.127.227.21",
+			actualPubkey:   "active-pubkey",
+			expectedIP:     "79.127.227.20",
+			expectedPubkey: "active-pubkey",
+			errorContains:  "does not match expected IP",
+		},
+		{
+			name:           "pubkey mismatch",
+			actualIP:       "79.127.227.20",
+			actualPubkey:   "stale-pubkey",
+			expectedIP:     "79.127.227.20",
+			expectedPubkey: "active-pubkey",
+			errorContains:  "does not match expected pubkey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateActiveGossipIdentity(tt.actualIP, tt.actualPubkey, tt.expectedIP, tt.expectedPubkey)
+			if tt.errorContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorContains)
+		})
+	}
+}

--- a/internal/solana/client.go
+++ b/internal/solana/client.go
@@ -156,21 +156,38 @@ func wrapLocalGetClusterNodesErr(err error) error {
 }
 
 func (c *Client) nodeFromIP(ip string) (node *rpc.GetClusterNodesResult, err error) {
-	nodes, err := c.getClusterNodes()
-	if err != nil {
-		return nil, err
+	localNodes, localErr := c.getClusterNodes()
+	if localErr == nil {
+		if node := findGossipNodeFromIP(localNodes, ip); node != nil {
+			c.loggerLocal.Debug("gossip peer found by ip", "ip", ip, "node_count", len(localNodes))
+			return node, nil
+		}
+		c.loggerLocal.Debug("gossip peer not found by ip", "ip", ip, "node_count", len(localNodes))
+	} else {
+		c.loggerLocal.Debug("failed to query gossip peer by ip", "ip", ip, "err", localErr)
 	}
 
+	clusterNodes, clusterErr := c.networkRPCClient.GetClusterNodes(context.Background())
+	if clusterErr == nil {
+		if node := findGossipNodeFromIP(clusterNodes, ip); node != nil {
+			c.loggerNetwork.Debug("gossip peer found by ip", "ip", ip, "node_count", len(clusterNodes))
+			return node, nil
+		}
+		c.loggerNetwork.Debug("gossip peer not found by ip", "ip", ip, "node_count", len(clusterNodes))
+	} else {
+		c.loggerNetwork.Debug("failed to query gossip peer by ip", "ip", ip, "err", clusterErr)
+	}
+
+	return nil, gossipNodeFromIPError(ip, len(localNodes), localErr, len(clusterNodes), clusterErr)
+}
+
+func findGossipNodeFromIP(nodes []*rpc.GetClusterNodesResult, ip string) *rpc.GetClusterNodesResult {
 	for _, node := range nodes {
-		if node.Gossip != nil {
-			gossipIP := strings.Split(*node.Gossip, ":")[0]
-			if gossipIP == ip {
-				return node, nil
-			}
+		if node != nil && node.Gossip != nil && strings.Split(*node.Gossip, ":")[0] == ip {
+			return node
 		}
 	}
-
-	return nil, fmt.Errorf("gossip node not found for ip: %s", ip)
+	return nil
 }
 
 func (c *Client) gossipNodeFromPubkey(pubkey string) (node *rpc.GetClusterNodesResult, err error) {
@@ -225,6 +242,23 @@ func gossipNodeFromPubkeyError(pubkey string, localCount int, localErr error, cl
 	)
 }
 
+func gossipNodeFromIPError(ip string, localCount int, localErr error, clusterCount int, clusterErr error) error {
+	localResult := fmt.Sprintf("returned %d nodes without a match", localCount)
+	if localErr != nil {
+		localResult = fmt.Sprintf("failed: %v", localErr)
+	}
+	clusterResult := fmt.Sprintf("returned %d nodes without a match", clusterCount)
+	if clusterErr != nil {
+		clusterResult = fmt.Sprintf("failed: %v", clusterErr)
+	}
+	return fmt.Errorf(
+		"gossip node not found for ip: %s (local RPC %s; cluster RPC %s)",
+		ip,
+		localResult,
+		clusterResult,
+	)
+}
+
 // NodeFromIPWithExpectedPubkey returns a Node from an IP address, preferring the entry
 // whose pubkey matches expectedPubkey. During a gossip identity transition, both the old
 // and new CRDS entries for a node briefly coexist; this method returns the expected entry
@@ -239,14 +273,49 @@ func (c *Client) NodeFromIPWithExpectedPubkey(ip, expectedPubkey string) (*Node,
 }
 
 func (c *Client) nodeFromIPWithExpectedPubkey(ip, expectedPubkey string) (*rpc.GetClusterNodesResult, error) {
-	nodes, err := c.getClusterNodes()
-	if err != nil {
-		return nil, err
+	localNodes, localErr := c.getClusterNodes()
+	var localFirstMatch *rpc.GetClusterNodesResult
+	if localErr == nil {
+		localExactMatch, firstMatch := findGossipNodeFromIPWithExpectedPubkey(localNodes, ip, expectedPubkey)
+		if localExactMatch != nil {
+			c.loggerLocal.Debug("gossip peer found by ip and expected pubkey", "ip", ip, "pubkey", expectedPubkey, "node_count", len(localNodes))
+			return localExactMatch, nil
+		}
+		localFirstMatch = firstMatch
+		c.loggerLocal.Debug("gossip peer not found by ip and expected pubkey", "ip", ip, "pubkey", expectedPubkey, "node_count", len(localNodes), "ip_match", firstMatch != nil)
+	} else {
+		c.loggerLocal.Debug("failed to query gossip peer by ip and expected pubkey", "ip", ip, "pubkey", expectedPubkey, "err", localErr)
 	}
 
-	var firstMatch *rpc.GetClusterNodesResult
+	clusterNodes, clusterErr := c.networkRPCClient.GetClusterNodes(context.Background())
+	var clusterFirstMatch *rpc.GetClusterNodesResult
+	if clusterErr == nil {
+		clusterExactMatch, firstMatch := findGossipNodeFromIPWithExpectedPubkey(clusterNodes, ip, expectedPubkey)
+		if clusterExactMatch != nil {
+			c.loggerNetwork.Debug("gossip peer found by ip and expected pubkey", "ip", ip, "pubkey", expectedPubkey, "node_count", len(clusterNodes))
+			return clusterExactMatch, nil
+		}
+		clusterFirstMatch = firstMatch
+		c.loggerNetwork.Debug("gossip peer not found by ip and expected pubkey", "ip", ip, "pubkey", expectedPubkey, "node_count", len(clusterNodes), "ip_match", firstMatch != nil)
+	} else {
+		c.loggerNetwork.Debug("failed to query gossip peer by ip and expected pubkey", "ip", ip, "pubkey", expectedPubkey, "err", clusterErr)
+	}
+
+	if localFirstMatch != nil {
+		c.loggerLocal.Debug("using stale gossip peer found by ip", "ip", ip, "expected_pubkey", expectedPubkey, "actual_pubkey", localFirstMatch.Pubkey.String())
+		return localFirstMatch, nil
+	}
+	if clusterFirstMatch != nil {
+		c.loggerNetwork.Debug("using stale gossip peer found by ip", "ip", ip, "expected_pubkey", expectedPubkey, "actual_pubkey", clusterFirstMatch.Pubkey.String())
+		return clusterFirstMatch, nil
+	}
+
+	return nil, gossipNodeFromIPError(ip, len(localNodes), localErr, len(clusterNodes), clusterErr)
+}
+
+func findGossipNodeFromIPWithExpectedPubkey(nodes []*rpc.GetClusterNodesResult, ip, expectedPubkey string) (exactMatch, firstMatch *rpc.GetClusterNodesResult) {
 	for _, node := range nodes {
-		if node.Gossip == nil {
+		if node == nil || node.Gossip == nil {
 			continue
 		}
 		gossipIP := strings.Split(*node.Gossip, ":")[0]
@@ -255,17 +324,13 @@ func (c *Client) nodeFromIPWithExpectedPubkey(ip, expectedPubkey string) (*rpc.G
 		}
 		// Found a node at this IP — prefer the one with the expected pubkey
 		if node.Pubkey.String() == expectedPubkey {
-			return node, nil
+			return node, firstMatch
 		}
 		if firstMatch == nil {
 			firstMatch = node // stale entry — keep as fallback
 		}
 	}
-
-	if firstMatch != nil {
-		return firstMatch, nil
-	}
-	return nil, fmt.Errorf("gossip node not found for ip: %s", ip)
+	return nil, firstMatch
 }
 
 // GetCreditRankedVoteAccountFromPubkey returns the credit rank-sorted current vote accounts rank is the difference

--- a/internal/solana/client_test.go
+++ b/internal/solana/client_test.go
@@ -97,7 +97,7 @@ func TestNewRPCClient_CustomAverageSlotDuration(t *testing.T) {
 
 func TestGossipClient_NodeFromIP_Success(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Setup mock expectations
 	expectedNodes := []*rpc.GetClusterNodesResult{
@@ -128,11 +128,12 @@ func TestGossipClient_NodeFromIP_Success(t *testing.T) {
 	assert.Equal(t, "1.16.0", node.Version())
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertNotCalled(t, "GetClusterNodes", mock.Anything)
 }
 
 func TestGossipClient_NodeFromIP_NotFound(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Setup mock expectations
 	expectedNodes := []*rpc.GetClusterNodesResult{
@@ -145,6 +146,7 @@ func TestGossipClient_NodeFromIP_NotFound(t *testing.T) {
 	}
 
 	localMock.On("GetClusterNodes", mock.Anything).Return(expectedNodes, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return(expectedNodes, nil)
 
 	// Test the function
 	node, err := client.NodeFromIP("192.168.1.999")
@@ -155,14 +157,16 @@ func TestGossipClient_NodeFromIP_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "gossip node not found for ip: 192.168.1.999")
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestGossipClient_NodeFromIP_RPCError(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Setup mock expectations
 	localMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("RPC connection failed"))
+	networkMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("cluster RPC failed"))
 
 	// Test the function
 	node, err := client.NodeFromIP("192.168.1.100")
@@ -171,13 +175,15 @@ func TestGossipClient_NodeFromIP_RPCError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, node)
 	assert.Contains(t, err.Error(), "RPC connection failed")
+	assert.Contains(t, err.Error(), "cluster RPC failed")
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestGossipClient_NodeFromIP_NilGossip(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Setup mock expectations - node with nil gossip
 	expectedNodes := []*rpc.GetClusterNodesResult{
@@ -190,6 +196,7 @@ func TestGossipClient_NodeFromIP_NilGossip(t *testing.T) {
 	}
 
 	localMock.On("GetClusterNodes", mock.Anything).Return(expectedNodes, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return(expectedNodes, nil)
 
 	// Test the function
 	node, err := client.NodeFromIP("192.168.1.100")
@@ -200,6 +207,45 @@ func TestGossipClient_NodeFromIP_NilGossip(t *testing.T) {
 	assert.Contains(t, err.Error(), "gossip node not found for ip: 192.168.1.100")
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
+}
+
+func TestGossipClient_NodeFromIP_ClusterFallback(t *testing.T) {
+	client, localMock, networkMock := createTestClient()
+	targetNode := &rpc.GetClusterNodesResult{
+		Pubkey:  createTestPublicKey(2),
+		Gossip:  stringPtr("79.127.227.20:8001"),
+		Version: stringPtr("1.1.3"),
+	}
+	localMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{targetNode}, nil)
+
+	node, err := client.NodeFromIP("79.127.227.20")
+
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, targetNode.Pubkey.String(), node.PubKey())
+	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
+}
+
+func TestGossipClient_NodeFromIP_ClusterFallbackAfterLocalRPCError(t *testing.T) {
+	client, localMock, networkMock := createTestClient()
+	targetNode := &rpc.GetClusterNodesResult{
+		Pubkey:  createTestPublicKey(2),
+		Gossip:  stringPtr("79.127.227.20:8001"),
+		Version: stringPtr("1.1.3"),
+	}
+	localMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("local RPC unavailable"))
+	networkMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{targetNode}, nil)
+
+	node, err := client.NodeFromIP("79.127.227.20")
+
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, targetNode.Pubkey.String(), node.PubKey())
+	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestGossipClient_NodeFromPubkey_Success(t *testing.T) {
@@ -345,7 +391,7 @@ func TestGossipClient_NodeFromPubkey_ClusterFallbackAfterLocalRPCError(t *testin
 }
 
 func TestNodeFromIPWithExpectedPubkey_MatchFound(t *testing.T) {
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	expectedPubkey := createTestPublicKey(1)
 	nodes := []*rpc.GetClusterNodesResult{
@@ -360,6 +406,7 @@ func TestNodeFromIPWithExpectedPubkey_MatchFound(t *testing.T) {
 	assert.Equal(t, expectedPubkey.String(), node.PubKey())
 	assert.Equal(t, "192.168.1.10", node.IP())
 	localMock.AssertExpectations(t)
+	networkMock.AssertNotCalled(t, "GetClusterNodes", mock.Anything)
 }
 
 // TestNodeFromIPWithExpectedPubkey_DualEntry_StaleFirst confirms that when two CRDS entries
@@ -409,13 +456,14 @@ func TestNodeFromIPWithExpectedPubkey_DualEntry_ExpectedFirst_ReturnsExpected(t 
 // the expected pubkey isn't at the IP yet (switch not yet in gossip), the first entry is
 // returned as a fallback so callers can inspect what pubkey is currently visible.
 func TestNodeFromIPWithExpectedPubkey_ExpectedNotPresent_ReturnsFirstMatch(t *testing.T) {
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	stalePubkey := createTestPublicKey(2) // only stale entry visible so far
 	nodes := []*rpc.GetClusterNodesResult{
 		{Pubkey: stalePubkey, Gossip: stringPtr("192.168.1.10:8001"), Version: stringPtr("1.16.0")},
 	}
 	localMock.On("GetClusterNodes", mock.Anything).Return(nodes, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, nil)
 
 	expectedPubkey := createTestPublicKey(1)
 	node, err := client.NodeFromIPWithExpectedPubkey("192.168.1.10", expectedPubkey.String())
@@ -424,15 +472,37 @@ func TestNodeFromIPWithExpectedPubkey_ExpectedNotPresent_ReturnsFirstMatch(t *te
 	require.NotNil(t, node)
 	assert.Equal(t, stalePubkey.String(), node.PubKey()) // stale returned as fallback
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
+}
+
+func TestNodeFromIPWithExpectedPubkey_ClusterExactMatchPreferredOverLocalStaleMatch(t *testing.T) {
+	client, localMock, networkMock := createTestClient()
+	stalePubkey := createTestPublicKey(2)
+	expectedPubkey := createTestPublicKey(1)
+	localMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{
+		{Pubkey: stalePubkey, Gossip: stringPtr("192.168.1.10:8001"), Version: stringPtr("1.16.0")},
+	}, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{
+		{Pubkey: expectedPubkey, Gossip: stringPtr("192.168.1.10:8001"), Version: stringPtr("1.16.0")},
+	}, nil)
+
+	node, err := client.NodeFromIPWithExpectedPubkey("192.168.1.10", expectedPubkey.String())
+
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, expectedPubkey.String(), node.PubKey())
+	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestNodeFromIPWithExpectedPubkey_NotFound(t *testing.T) {
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	nodes := []*rpc.GetClusterNodesResult{
 		{Pubkey: createTestPublicKey(1), Gossip: stringPtr("192.168.1.100:8001"), Version: stringPtr("1.16.0")},
 	}
 	localMock.On("GetClusterNodes", mock.Anything).Return(nodes, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return(nodes, nil)
 
 	node, err := client.NodeFromIPWithExpectedPubkey("10.0.0.99", createTestPublicKey(1).String())
 
@@ -440,19 +510,23 @@ func TestNodeFromIPWithExpectedPubkey_NotFound(t *testing.T) {
 	assert.Nil(t, node)
 	assert.Contains(t, err.Error(), "gossip node not found for ip: 10.0.0.99")
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestNodeFromIPWithExpectedPubkey_RPCError(t *testing.T) {
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	localMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("RPC connection failed"))
+	networkMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("cluster RPC failed"))
 
 	node, err := client.NodeFromIPWithExpectedPubkey("192.168.1.10", createTestPublicKey(1).String())
 
 	assert.Error(t, err)
 	assert.Nil(t, node)
 	assert.Contains(t, err.Error(), "RPC connection failed")
+	assert.Contains(t, err.Error(), "cluster RPC failed")
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestNode_IP(t *testing.T) {
@@ -540,7 +614,7 @@ func TestNode_Refresh_Success(t *testing.T) {
 
 func TestNode_Refresh_Error(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Create initial node
 	node := &Node{
@@ -553,6 +627,7 @@ func TestNode_Refresh_Error(t *testing.T) {
 
 	// Setup mock expectations for refresh failure
 	localMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("RPC connection failed"))
+	networkMock.On("GetClusterNodes", mock.Anything).Return([]*rpc.GetClusterNodesResult{}, errors.New("cluster RPC failed"))
 
 	// Test refresh
 	err := node.Refresh(client)
@@ -560,13 +635,15 @@ func TestNode_Refresh_Error(t *testing.T) {
 	// Assertions
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "RPC connection failed")
+	assert.Contains(t, err.Error(), "cluster RPC failed")
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestNode_Refresh_NodeNotFound(t *testing.T) {
 	// Create test client with mocks
-	client, localMock, _ := createTestClient()
+	client, localMock, networkMock := createTestClient()
 
 	// Create initial node
 	node := &Node{
@@ -587,6 +664,7 @@ func TestNode_Refresh_NodeNotFound(t *testing.T) {
 	}
 
 	localMock.On("GetClusterNodes", mock.Anything).Return(updatedNodes, nil)
+	networkMock.On("GetClusterNodes", mock.Anything).Return(updatedNodes, nil)
 
 	// Test refresh
 	err := node.Refresh(client)
@@ -596,6 +674,7 @@ func TestNode_Refresh_NodeNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "gossip node not found for ip: 192.168.1.100")
 
 	localMock.AssertExpectations(t)
+	networkMock.AssertExpectations(t)
 }
 
 func TestGossipClient_GetCreditRankedVoteAccountFromPubkey_Success(t *testing.T) {


### PR DESCRIPTION
  - Apply local-first, cluster-RPC fallback to all IP-based gossip lookups.
  - Validate incoming active nodes using both public IP and configured identity pubkey.
  - Prefer exact identity matches across RPC sources before accepting stale gossip entries.
  - Add source-specific debug logs and combined lookup error diagnostics.
  - Add tests for fallback, stale gossip entries, RPC failures, and handshake validation.